### PR TITLE
fix: widen fastapi constraint to allow newer versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-fastapi = {extras = ["standard"], version = "^0.115.12"}
+fastapi = {extras = ["standard"], version = ">=0.115.0,<1"}
 nlip-sdk = "^0.1.2"
 
 


### PR DESCRIPTION
Widen fastapi constraint from ^0.115.12 to >=0.115.0,<1 to fix starlette CVEs.

Fixes ag2ai/ag2#2894